### PR TITLE
chore: migrate create-github-app-token from app-id to client-id

### DIFF
--- a/.github/workflows/delete-repos-delete.yml
+++ b/.github/workflows/delete-repos-delete.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/create-github-app-token@v3
         id: app-token
         with:
-          app-id: ${{ vars.APP_ID }}
+          client-id: ${{ vars.APP_CLIENT_ID }}
           private-key: ${{ secrets.PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
 

--- a/.github/workflows/delete-repos-prepare.yml
+++ b/.github/workflows/delete-repos-prepare.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/create-github-app-token@v3
         id: app-token
         with:
-          app-id: ${{ vars.APP_ID }}
+          client-id: ${{ vars.APP_CLIENT_ID }}
           private-key: ${{ secrets.PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
 

--- a/.github/workflows/new-repo-create.yml
+++ b/.github/workflows/new-repo-create.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/create-github-app-token@v3
         id: app-token
         with:
-          app-id: ${{ vars.APP_ID }}
+          client-id: ${{ vars.APP_CLIENT_ID }}
           private-key: ${{ secrets.PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
 

--- a/.github/workflows/new-repo-prepare.yml
+++ b/.github/workflows/new-repo-prepare.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/create-github-app-token@v3
         id: app-token
         with:
-          app-id: ${{ vars.APP_ID }}
+          client-id: ${{ vars.APP_CLIENT_ID }}
           private-key: ${{ secrets.PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
 


### PR DESCRIPTION
## Summary

Migrates `actions/create-github-app-token` from the deprecated `app-id` input to `client-id`. The action was already on `@v3`.

### Changes
- 🔄 Renamed `app-id` input to `client-id`
- 🔄 Updated variable references from `APP_ID` to `APP_CLIENT_ID`

### After merging
- ✅ Delete the old `APP_ID` repo variable (already done)