### PR TITLE
chore: rename app vars/secrets to GITHUB_APP_* convention

### DIFF
--- a/.github/workflows/delete-repos-delete.yml
+++ b/.github/workflows/delete-repos-delete.yml
@@ -32,8 +32,8 @@ jobs:
       - uses: actions/create-github-app-token@v3
         id: app-token
         with:
-          client-id: ${{ vars.APP_CLIENT_ID }}
-          private-key: ${{ secrets.PRIVATE_KEY }}
+          client-id: ${{ vars.GITHUB_APP_CLIENT_ID }}
+          private-key: ${{ secrets.GITHUB_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
 
       # doing this again in case someone else renamed the issue

--- a/.github/workflows/delete-repos-prepare.yml
+++ b/.github/workflows/delete-repos-prepare.yml
@@ -27,8 +27,8 @@ jobs:
       - uses: actions/create-github-app-token@v3
         id: app-token
         with:
-          client-id: ${{ vars.APP_CLIENT_ID }}
-          private-key: ${{ secrets.PRIVATE_KEY }}
+          client-id: ${{ vars.GITHUB_APP_CLIENT_ID }}
+          private-key: ${{ secrets.GITHUB_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
 
       - name: Parse Issue

--- a/.github/workflows/new-repo-create.yml
+++ b/.github/workflows/new-repo-create.yml
@@ -26,8 +26,8 @@ jobs:
       - uses: actions/create-github-app-token@v3
         id: app-token
         with:
-          client-id: ${{ vars.APP_CLIENT_ID }}
-          private-key: ${{ secrets.PRIVATE_KEY }}
+          client-id: ${{ vars.GITHUB_APP_CLIENT_ID }}
+          private-key: ${{ secrets.GITHUB_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
 
       - name: Parse Issue

--- a/.github/workflows/new-repo-prepare.yml
+++ b/.github/workflows/new-repo-prepare.yml
@@ -27,8 +27,8 @@ jobs:
       - uses: actions/create-github-app-token@v3
         id: app-token
         with:
-          client-id: ${{ vars.APP_CLIENT_ID }}
-          private-key: ${{ secrets.PRIVATE_KEY }}
+          client-id: ${{ vars.GITHUB_APP_CLIENT_ID }}
+          private-key: ${{ secrets.GITHUB_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
 
       - name: Parse Issue


### PR DESCRIPTION
## Summary

Renames variable and secret references to match the recommended naming convention from [actions/create-github-app-token](https://github.com/actions/create-github-app-token) docs:

- `vars.APP_CLIENT_ID` → `vars.GITHUB_APP_CLIENT_ID`
- `secrets.PRIVATE_KEY` / `secrets.APP_PRIVATE_KEY` → `secrets.GITHUB_APP_PRIVATE_KEY`

### 🧹 After Merging
- Delete the old `APP_CLIENT_ID` variable (if still present)
- Create/rename the secret from `PRIVATE_KEY`/`APP_PRIVATE_KEY` to `GITHUB_APP_PRIVATE_KEY`