### PR TITLE
chore: rename secret PRIVATE_KEY to APP_PRIVATE_KEY

### DIFF
--- a/.github/workflows/delete-repos-delete.yml
+++ b/.github/workflows/delete-repos-delete.yml
@@ -33,7 +33,7 @@ jobs:
         id: app-token
         with:
           client-id: ${{ vars.APP_CLIENT_ID }}
-          private-key: ${{ secrets.PRIVATE_KEY }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
 
       # doing this again in case someone else renamed the issue

--- a/.github/workflows/delete-repos-prepare.yml
+++ b/.github/workflows/delete-repos-prepare.yml
@@ -28,7 +28,7 @@ jobs:
         id: app-token
         with:
           client-id: ${{ vars.APP_CLIENT_ID }}
-          private-key: ${{ secrets.PRIVATE_KEY }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
 
       - name: Parse Issue

--- a/.github/workflows/new-repo-create.yml
+++ b/.github/workflows/new-repo-create.yml
@@ -27,7 +27,7 @@ jobs:
         id: app-token
         with:
           client-id: ${{ vars.APP_CLIENT_ID }}
-          private-key: ${{ secrets.PRIVATE_KEY }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
 
       - name: Parse Issue

--- a/.github/workflows/new-repo-prepare.yml
+++ b/.github/workflows/new-repo-prepare.yml
@@ -28,7 +28,7 @@ jobs:
         id: app-token
         with:
           client-id: ${{ vars.APP_CLIENT_ID }}
-          private-key: ${{ secrets.PRIVATE_KEY }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
 
       - name: Parse Issue


### PR DESCRIPTION
## Summary

Renames secret references from `secrets.PRIVATE_KEY` to `secrets.APP_PRIVATE_KEY` for consistency across all repos.

### ⚠️ Before Merging
1. Create a new secret `APP_PRIVATE_KEY` with the same value as `PRIVATE_KEY`
2. Then merge this PR
3. Delete the old `PRIVATE_KEY` secret